### PR TITLE
show hfjobs url after triggering job

### DIFF
--- a/hfjobs/commands/run.py
+++ b/hfjobs/commands/run.py
@@ -126,6 +126,8 @@ class RunCommand(BaseCommand):
 
         # Always print the job ID to the user
         print(f"Job started with ID: {job_id}")
+        print(f"View at: https://huggingface.co/jobs/{username}/{job_id}")
+
         if self.detach:
             return
 


### PR DESCRIPTION
Found myself wanting to have a click to view from triggering job (_similar to git showing git pull request url_) etc.

ex:
```
Job started with ID: t2aw4uwoW_7ZC6UDxV0kVrXRL
View at: https://huggingface.co/jobs/cfahlgren1/t2aw4uwoW_7ZC6UDxV0kVrXRL
```