### PR TITLE
Add minimal hfjobs uv run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,14 @@ That's it! You're now running code on Hugging Face's infrastructure. For more de
 usage: hfjobs <command> [<args>]
 
 positional arguments:
-  {inspect,logs,ps,run,cancel}
+  {inspect,logs,ps,run,cancel,uv}
                         hfjobs command helpers
     inspect             Display detailed information on one or more Jobs
     logs                Fetch the logs of a Job
     ps                  List Jobs
     run                 Run a Job
     cancel              Cancel a Job
+    uv                  Run UV scripts on Hugging Face infrastructure
 
 options:
   -h, --help            show this help message and exit
@@ -209,3 +210,23 @@ Available `--flavor` options:
 - TPU: `v5e-1x1`, `v5e-2x2`, `v5e-2x4`
 
 (updated in 03/25 from Hugging Face [suggested_hardware docs](https://huggingface.co/docs/hub/en/spaces-config-reference))
+
+## UV Scripts (Experimental)
+
+Run UV scripts (Python scripts with inline dependencies) on HF infrastructure:
+
+```bash
+# Run a UV script (creates temporary repo)
+hfjobs uv run my_script.py
+
+# Run with persistent repo
+hfjobs uv run my_script.py --repo my-uv-scripts
+
+# Run with GPU
+hfjobs uv run ml_training.py --flavor gpu-t4-small
+
+# Pass arguments to script
+hfjobs uv run process.py input.csv output.parquet --repo data-scripts
+```
+
+UV scripts are Python scripts that include their dependencies directly in the file using a special comment syntax. This makes them perfect for self-contained tasks that don't require complex project setups. Learn more about UV scripts in the [UV documentation](https://docs.astral.sh/uv/guides/scripts/).

--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ hfjobs uv run ml_training.py --flavor gpu-t4-small
 
 # Pass arguments to script
 hfjobs uv run process.py input.csv output.parquet --repo data-scripts
+
+# Run a script directly from a URL
+hfjobs uv run https://huggingface.co/datasets/username/scripts/resolve/main/example.py
 ```
 
 UV scripts are Python scripts that include their dependencies directly in the file using a special comment syntax. This makes them perfect for self-contained tasks that don't require complex project setups. Learn more about UV scripts in the [UV documentation](https://docs.astral.sh/uv/guides/scripts/).

--- a/hfjobs/cli.py
+++ b/hfjobs/cli.py
@@ -5,6 +5,7 @@ from .commands.logs import LogsCommand
 from .commands.ps import PsCommand
 from .commands.run import RunCommand
 from .commands.cancel import CancelCommand
+from .commands.uv import UvCommand
 
 def main():
     
@@ -17,6 +18,7 @@ def main():
     PsCommand.register_subcommand(commands_parser)
     RunCommand.register_subcommand(commands_parser)
     CancelCommand.register_subcommand(commands_parser)
+    UvCommand.register_subcommand(commands_parser)
 
     # Let's go
     args = parser.parse_args()

--- a/hfjobs/commands/uv.py
+++ b/hfjobs/commands/uv.py
@@ -203,6 +203,7 @@ hfjobs run ghcr.io/astral-sh/uv:python3.12-bookworm-slim \\
         return f"""---
 tags:
 - hfjobs-uv-script
+viewer: false
 ---
 
 # {repo_name}

--- a/hfjobs/commands/uv.py
+++ b/hfjobs/commands/uv.py
@@ -67,6 +67,7 @@ class UvCommand(BaseCommand):
 
     def _run_script(self, args):
         """Run a UV script on HF infrastructure."""
+        print("Note: hfjobs uv run is experimental and subject to change.")
         api = HfApi(token=args.token)
 
         if args.script.startswith("http://") or args.script.startswith("https://"):

--- a/hfjobs/commands/uv.py
+++ b/hfjobs/commands/uv.py
@@ -1,0 +1,219 @@
+"""UV run command for hfjobs - execute UV scripts on HF infrastructure."""
+
+import hashlib
+from argparse import Namespace
+from datetime import datetime
+from pathlib import Path
+
+from huggingface_hub import HfApi, create_repo
+from huggingface_hub.utils import RepositoryNotFoundError
+
+from . import BaseCommand
+from .run import RunCommand
+
+
+class UvCommand(BaseCommand):
+    """Run UV scripts on Hugging Face infrastructure."""
+
+    @staticmethod
+    def register_subcommand(parser):
+        """Register UV run subcommand."""
+        uv_parser = parser.add_parser(
+            "uv",
+            help="Run UV scripts on Hugging Face infrastructure",
+            description="Execute UV scripts (Python scripts with inline dependencies) using hfjobs",
+        )
+
+        subparsers = uv_parser.add_subparsers(
+            dest="uv_command", help="UV commands", required=True
+        )
+
+        # Run command only
+        run_parser = subparsers.add_parser(
+            "run",
+            help="Run a UV script on HF infrastructure",
+            description="Upload and execute a UV script using hfjobs",
+        )
+        run_parser.add_argument("script", help="UV script to run")
+        run_parser.add_argument(
+            "script_args", nargs="*", help="Arguments for the script", default=[]
+        )
+        run_parser.add_argument(
+            "--repo",
+            help="Repository name for the script (creates ephemeral if not specified)",
+        )
+        run_parser.add_argument(
+            "--flavor", default="cpu-basic", help="Hardware flavor (default: cpu-basic)"
+        )
+        run_parser.add_argument(
+            "-e", "--env", action="append", help="Environment variables"
+        )
+        run_parser.add_argument(
+            "-s", "--secret", action="append", help="Secret environment variables"
+        )
+        run_parser.add_argument("--timeout", help="Max duration (e.g., 30s, 5m, 1h)")
+        run_parser.add_argument(
+            "-d", "--detach", action="store_true", help="Run in background"
+        )
+        run_parser.add_argument("--token", help="HF token")
+        run_parser.set_defaults(func=UvCommand)
+
+    def __init__(self, args):
+        """Initialize the command with parsed arguments."""
+        self.args = args
+
+    def run(self):
+        """Execute UV command."""
+        if self.args.uv_command == "run":
+            self._run_script(self.args)
+
+    def _run_script(self, args):
+        """Run a UV script on HF infrastructure."""
+        api = HfApi()
+
+        # Check script exists
+        script_path = Path(args.script)
+        if not script_path.exists():
+            print(f"Error: Script not found: {args.script}")
+            return
+
+        # Determine repository
+        repo_id = self._determine_repository(args, api)
+        is_ephemeral = args.repo is None
+
+        # Create repo if needed
+        try:
+            api.repo_info(repo_id, repo_type="dataset")
+            if not is_ephemeral:
+                print(f"Using existing repository: {repo_id}")
+        except RepositoryNotFoundError:
+            print(f"Creating repository: {repo_id}")
+            create_repo(repo_id, repo_type="dataset", exist_ok=True)
+
+        # Upload script
+        print(f"Uploading {script_path.name}...")
+        with open(script_path, "r") as f:
+            script_content = f.read()
+
+        filename = script_path.name
+
+        api.upload_file(
+            path_or_fileobj=script_content.encode(),
+            path_in_repo=filename,
+            repo_id=repo_id,
+            repo_type="dataset",
+        )
+
+        script_url = (
+            f"https://huggingface.co/datasets/{repo_id}/resolve/main/{filename}"
+        )
+        repo_url = f"https://huggingface.co/datasets/{repo_id}"
+
+        print(f"✓ Script uploaded to: {repo_url}/blob/main/{filename}")
+
+        # Create and upload minimal README
+        readme_content = self._create_minimal_readme(repo_id, filename, is_ephemeral)
+        api.upload_file(
+            path_or_fileobj=readme_content.encode(),
+            path_in_repo="README.md",
+            repo_id=repo_id,
+            repo_type="dataset",
+        )
+
+        if is_ephemeral:
+            print(f"✓ Temporary repository created: {repo_id}")
+
+        # Prepare docker image (always use Python 3.12)
+        docker_image = "ghcr.io/astral-sh/uv:python3.12-bookworm-slim"
+
+        # Build command
+        command = ["uv", "run", script_url] + args.script_args
+
+        # Create RunCommand args
+        run_args = Namespace(
+            dockerImage=docker_image,
+            command=command,
+            env=args.env,
+            secret=args.secret,
+            env_file=None,
+            secret_env_file=None,
+            flavor=args.flavor,
+            timeout=args.timeout,
+            detach=args.detach,
+            token=args.token,
+        )
+
+        print("Starting job on HF infrastructure...")
+        RunCommand(run_args).run()
+
+    def _determine_repository(self, args, api):
+        """Determine which repository to use for the script."""
+        # Use provided repo
+        if args.repo:
+            repo_id = args.repo
+            if "/" not in repo_id:
+                username = api.whoami()["name"]
+                repo_id = f"{username}/{repo_id}"
+            return repo_id
+
+        # Create ephemeral repo
+        username = api.whoami()["name"]
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+
+        # Simple hash for uniqueness
+        script_hash = hashlib.md5(Path(args.script).read_bytes()).hexdigest()[:8]
+
+        return f"{username}/hfjobs-uv-run-{timestamp}-{script_hash}"
+
+    def _create_minimal_readme(self, repo_id, script_name, is_ephemeral):
+        """Create minimal README content."""
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC")
+
+        if is_ephemeral:
+            # Ephemeral repository README
+            readme = f"""---
+tags:
+- hfjobs-uv-script
+- ephemeral
+---
+
+# UV Script: {script_name}
+
+Executed via `hfjobs uv run` on {timestamp}
+
+## Run this script
+
+```bash
+hfjobs run ghcr.io/astral-sh/uv:python3.12-bookworm-slim \\
+  uv run https://huggingface.co/datasets/{repo_id}/resolve/main/{script_name}
+```
+
+---
+*Created with [hfjobs](https://github.com/huggingface/hfjobs)*
+"""
+        else:
+            # Named repository README
+            repo_name = repo_id.split("/")[-1]
+            readme = f"""---
+tags:
+- hfjobs-uv-script
+---
+
+# {repo_name}
+
+UV scripts repository
+
+## Scripts
+- `{script_name}` - Added {timestamp}
+
+## Run
+
+```bash
+hfjobs uv run {script_name} --repo {repo_name}
+```
+
+---
+*Created with [hfjobs](https://github.com/huggingface/hfjobs)*
+"""
+
+        return readme

--- a/hfjobs/commands/uv.py
+++ b/hfjobs/commands/uv.py
@@ -71,10 +71,7 @@ class UvCommand(BaseCommand):
         """Run a UV script on HF infrastructure."""
         api = HfApi(token=args.token)
 
-        # Check if script is a URL
-        is_url = args.script.startswith("http://") or args.script.startswith("https://")
-
-        if is_url:
+        if args.script.startswith("http://") or args.script.startswith("https://"):
             # Direct URL execution - no upload needed
             script_url = args.script
             print(f"Running script from URL: {script_url}")
@@ -181,7 +178,7 @@ class UvCommand(BaseCommand):
 
         if is_ephemeral:
             # Ephemeral repository README
-            readme = f"""---
+            return f"""---
 tags:
 - hfjobs-uv-script
 - ephemeral
@@ -201,10 +198,9 @@ hfjobs run ghcr.io/astral-sh/uv:python3.12-bookworm-slim \\
 ---
 *Created with [hfjobs](https://github.com/huggingface/hfjobs)*
 """
-        else:
-            # Named repository README
-            repo_name = repo_id.split("/")[-1]
-            readme = f"""---
+        # Named repository README
+        repo_name = repo_id.split("/")[-1]
+        return f"""---
 tags:
 - hfjobs-uv-script
 ---
@@ -225,5 +221,3 @@ hfjobs uv run {script_name} --repo {repo_name}
 ---
 *Created with [hfjobs](https://github.com/huggingface/hfjobs)*
 """
-
-        return readme

--- a/hfjobs/commands/uv.py
+++ b/hfjobs/commands/uv.py
@@ -20,8 +20,7 @@ class UvCommand(BaseCommand):
         """Register UV run subcommand."""
         uv_parser = parser.add_parser(
             "uv",
-            help="Run UV scripts on Hugging Face infrastructure",
-            description="Execute UV scripts (Python scripts with inline dependencies) using hfjobs",
+            help="Run UV scripts (Python with inline dependencies) on HF infrastructure",
         )
 
         subparsers = uv_parser.add_subparsers(
@@ -31,8 +30,7 @@ class UvCommand(BaseCommand):
         # Run command only
         run_parser = subparsers.add_parser(
             "run",
-            help="Run a UV script on HF infrastructure",
-            description="Execute a UV script using hfjobs (from local file or URL)",
+            help="Run a UV script (local file or URL) on HF infrastructure",
         )
         run_parser.add_argument("script", help="UV script to run (local file or URL)")
         run_parser.add_argument(

--- a/hfjobs/commands/uv.py
+++ b/hfjobs/commands/uv.py
@@ -49,6 +49,14 @@ class UvCommand(BaseCommand):
         run_parser.add_argument(
             "-s", "--secret", action="append", help="Secret environment variables"
         )
+        run_parser.add_argument(
+            "--env-file", type=str, help="Read in a file of environment variables."
+        )
+        run_parser.add_argument(
+            "--secret-env-file",
+            type=str,
+            help="Read in a file of secret environment variables.",
+        )
         run_parser.add_argument("--timeout", help="Max duration (e.g., 30s, 5m, 1h)")
         run_parser.add_argument(
             "-d", "--detach", action="store_true", help="Run in background"
@@ -141,8 +149,8 @@ class UvCommand(BaseCommand):
             command=command,
             env=args.env,
             secret=args.secret,
-            env_file=None,
-            secret_env_file=None,
+            env_file=args.env_file,
+            secret_env_file=args.secret_env_file,
             flavor=args.flavor,
             timeout=args.timeout,
             detach=args.detach,


### PR DESCRIPTION
WIP adds a super minimal MVP version of the UV run (will keep #7 for further UX experiments with different workflows, etc.). 

## Usage

```bash
hfjobs uv --help
usage: hfjobs <command> [<args>] uv [-h] {run} ...

positional arguments:
  {run}       UV commands
    run       Run a UV script (local file or URL) on HF infrastructure

options:
  -h, --help  show this help message and exit
```

```
hfjobs uv run --help
usage: hfjobs <command> [<args>] uv run [-h] [--repo REPO] [--flavor FLAVOR] [-e ENV] [-s SECRET] [--timeout TIMEOUT] [-d] [--token TOKEN] script [script_args ...]

positional arguments:
  script                UV script to run (local file or URL)
  script_args           Arguments for the script

options:
  -h, --help            show this help message and exit
  --repo REPO           Repository name for the script (creates ephemeral if not specified)
  --flavor FLAVOR       Hardware flavor (default: cpu-basic)
  -e ENV, --env ENV     Environment variables
  -s SECRET, --secret SECRET
                        Secret environment variables
  --timeout TIMEOUT     Max duration (e.g., 30s, 5m, 1h)
  -d, --detach          Run in background
  --token TOKEN         HF token
```

## What are UV scripts?

UV scripts are Python scripts with inline dependencies. Here's a simple example:

```python
# /// script
# requires-python = ">=3.10"
# dependencies = [
#     "requests",
#     "rich",
# ]
# ///

import requests
from rich import print

response = requests.get("https://api.github.com")
print(f"[green]GitHub API status:[/green] {response.status_code}")
```

## Examples

Supports running from a local Python file:

<img width="799" alt="Screenshot 2025-07-10 at 09 56 42" src="https://github.com/user-attachments/assets/2962d5a4-5dda-4ed2-8c98-e614bdadf4a2" />

And from a public URL:

<img width="799" alt="Screenshot 2025-07-10 at 09 57 19" src="https://github.com/user-attachments/assets/bdaea0d3-1662-4ae7-aa90-6900faa3d6d6" />

## Note on private repositories

Currently, it only supports using a public repository for the ephemeral storage of scripts. I would suggest we start with that for the launch and add a `--private` flag post-launch. @lhoestq WDYT?